### PR TITLE
Fix broken `isValidGitRepo` validation

### DIFF
--- a/app/src/main/java/com/viscouspot/gitsync/util/Helper.kt
+++ b/app/src/main/java/com/viscouspot/gitsync/util/Helper.kt
@@ -266,7 +266,7 @@ object Helper {
     }
 
     fun isValidGitRepo(url: String): String? {
-        val validDomains = listOf(defaultDomainMap.values)
+        val validDomains = defaultDomainMap.values.toList()
         val regex = Regex("^https?://([a-zA-Z0-9.-]+)/(\\S+)/(\\S+)\$")
 
         return when {


### PR DESCRIPTION
Every time I'd try to add my repository by specifying the path, it would fail saying "URL domain is not allowed". The culprit is that `listOf(defaultDomainMap.values)` returns a nested list, which won't work with the validation.