### PR TITLE
Fix repo list fetching pagination for Github

### DIFF
--- a/app/src/main/java/com/viscouspot/gitsync/util/provider/GithubManager.kt
+++ b/app/src/main/java/com/viscouspot/gitsync/util/provider/GithubManager.kt
@@ -130,7 +130,7 @@ class GithubManager(private val context: Context) : GitProviderManager {
                 val link = response.headers["link"] ?: ""
 
                 if (link != "") {
-                    val regex = "<(.*?)>; rel=\"next\"".toRegex()
+                    val regex = "<([^>]+)>; rel=\"next\"".toRegex()
 
                     val match = regex.find(link)
                     val result = match?.groups?.get(1)?.value


### PR DESCRIPTION
When user has more than 60 repositories on their user account, the pagination would silently fail & will repeatedly fetch first & second pages only. Example of the failure:

response from the header on the second request:
```
<https://api.github.com/user/repos?page=1>; rel="prev",
<https://api.github.com/user/repos?page=3>; rel="next",
<https://api.github.com/user/repos?page=4>; rel="last",
<https://api.github.com/user/repos?page=1>; rel="first"
```

This will parse the next page to be:
```
https://api.github.com/user/repos?page=1>; rel="prev", <https://api.github.com/user/repos?page=3
```

instead of `https://api.github.com/user/repos?page=3`.

The reason that fetch of the first page still "works" is that it treats the rest of the URL as query parameters probably.