### PR TITLE
Improve performance in big repos by adding files to stage explicitly

### DIFF
--- a/app/src/main/java/com/viscouspot/gitsync/util/GitManager.kt
+++ b/app/src/main/java/com/viscouspot/gitsync/util/GitManager.kt
@@ -265,11 +265,13 @@ class GitManager(private val context: Context, private val settingsManager: Sett
                 log(LogType.PushToRepo, "Adding Files to Stage")
 
                 git.add().apply {
-                    addFilepattern(".")
+                    status.uncommittedChanges.forEach { addFilepattern(it) }
+                    status.untracked.forEach { addFilepattern(it) }
                 }.call()
 
                 git.add().apply {
-                    addFilepattern(".")
+                    status.uncommittedChanges.forEach { addFilepattern(it) }
+                    status.untracked.forEach { addFilepattern(it) }
                     isUpdate = true
                 }.call()
 


### PR DESCRIPTION
In my big repo (>1 GB), it took several minutes to run "git add ." even on a one-line change.
With this fix, it works much faster and makes GitSync usable for me.