### PR TITLE
Fix split action mangling arm64-v8a apk path.

### DIFF
--- a/.github/workflows/generate-apk-release.yml
+++ b/.github/workflows/generate-apk-release.yml
@@ -86,20 +86,22 @@ jobs:
           keyPassword: ${{ secrets.RELEASE_SIGNING_PASSWORD }}
           buildToolsVersion: 34.0.0
 
-      - uses: jungwinter/split@v2
+      - name: Format App List
         id: signed_files
-        with:
-          msg: ${{ steps.sign_app.outputs.signedFiles }}
-          separator: ":"
+        run: |
+          {
+            echo "signedFiles<<SIGNED_FILES_EOF_DELIMETER"
+            echo "${{ steps.sign_app.outputs.signedFiles }}" | sed 's/:/\n/g'
+            echo "SIGNED_FILES_EOF_DELIMETER"
+          } >> "$GITHUB_OUTPUT"
+
 
       - name: Upload Release Build to Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: release-artifacts
           path: |
-            ${{ steps.signed_files.outputs._0 }}
-            ${{ steps.signed_files.outputs._1 }}
-            ${{ steps.signed_files.outputs._2 }}
+            ${{ steps.signed_files.outputs.signedFiles }}
             !*-release.apk
 
       - name: Build Changelog


### PR DESCRIPTION
## Issue

Current `Release OSS (APK)` github action uploads artifacts for 2 out of 3 architectures and skips `app-arm64-v8a-release-signed.apk`. This is because `Upload Release Build to Artifacts` step gets a mangled path from `Run jungwinter/split@v2` step. 

## Investigation

See [this](https://github.com/memst/GitSync/actions/runs/21014325431/job/60416149583) build I ran with debug output.

The step starts by receiving:
```
msg: /home/runner/work/GitSync/GitSync/build/app/outputs/flutter-apk/app-arm64-v8a-release-signed.apk:/home/runner/work/GitSync/GitSync/build/app/outputs/flutter-apk/app-armeabi-v7a-release-signed.apk:/home/runner/work/GitSync/GitSync/build/app/outputs/flutter-apk/app-x86_64-release-signed.apk
```

And ends with output:
```
##[debug]Set output length = 3
##[debug]Set output _0 = /github/workspace/build/app/outputs/flutter-apk/app-arm64-v8a-release-signed.apk
##[debug]Set output _1 = /home/runner/work/GitSync/GitSync/build/app/outputs/flutter-apk/app-armeabi-v7a-release-signed.apk
##[debug]Set output _2 = /home/runner/work/GitSync/GitSync/build/app/outputs/flutter-apk/app-x86_64-release-signed.apk
##[debug]Finishing: Run jungwinter/split@v2
```

The `_0` path is invalid and is ignored by the next step. The same behavior is present in all your builds as well, for example [this](https://github.com/ViscousPot/GitSync/actions/runs/20980037434/job/60302891508).

## Fix

I would have tried fixing the docker container, but using docker for this task is completely unnecessary because it only does some trivial string manipulation. The container can be replaced with the following bash command:
```
{
  echo "signedFiles<<SIGNED_FILES_EOF_DELIMETER"
  echo "${{ steps.sign_app.outputs.signedFiles }}" | sed 's/:/\n/g'
  echo "SIGNED_FILES_EOF_DELIMETER"
} >> "$GITHUB_OUTPUT"
```

The syntax is a copy of what is done in the [github docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#example-of-a-multiline-string).

## Test

I ran a trimmed down version of the action to show that my implementation works: https://github.com/memst/GitSync/actions/runs/21016321848