### PR TITLE
Fix: Handle recurring GitSync errors if a repository index is corrupted

### DIFF
--- a/rust/src/api/git_manager.rs
+++ b/rust/src/api/git_manager.rs
@@ -3406,12 +3406,14 @@ pub async fn get_conflicting(
         LogType::ConflictingFiles,
         "Getting local directory".to_string(),
     );
-    let repo = match Repository::open(path_string) {
-        Ok(repo) => repo,
-        Err(_) => return Vec::new(),
+    let Ok(repo) = Repository::open(path_string) else {
+        return Vec::new();
     };
 
-    let index = repo.index().unwrap();
+    let Ok(index) = repo.index() else {
+        return Vec::new();
+    };
+
     let mut conflicts = Vec::new();
 
     index.conflicts().unwrap().for_each(|conflict| {


### PR DESCRIPTION
Fix: Handle recurring GitSync errors if a repository itself is valid but its index is corrupted.

Uses `let Ok else` to safely open the index in get_conflicting, the last remaining place where wn unprotected unwrap() was used on the index, returning an empty vector if opening the index fails (possible if it's corrupted).

This prevents recurring failure messages from GitSync's scheduled repository scanning tasks if a repository is valid and openable but its index is corrupted and cannot be opened.

Also makes a minor simplification of the match of opening the repository into another let Ok else (as opening the index) since a repository opening error is always discarded anyway.

This only applies to get_conflicting, all other call sites of Repository::index() uses swl!(repo.index())?.