### PR TITLE
[Work in Progress / Sample] Recreate deleted Git index & git manager error handling fixes

### DIFF
--- a/lib/api/manager/git_manager.dart
+++ b/lib/api/manager/git_manager.dart
@@ -490,6 +490,15 @@ class GitManager {
     if (_indexCorruptionPatterns.any((p) => errorStr.contains(p))) {
       final indexFile = File('$dirPath/$gitIndexPath');
       if (await indexFile.exists()) await indexFile.delete();
+
+      await _runWithLock(priority: 1, GitManagerRs.voidRunWithLock, await _repoIndex, LogType.PruneCorruptedObjects, (dirPath) async {
+        try {
+          await GitManagerRs.recreateDeletedIndex(pathString: dirPath, log: _logWrapper);
+        } catch (e, stackTrace) {
+          Logger.logError(LogType.PruneCorruptedObjects, e, stackTrace);
+        }
+      });
+
       return true;
     }
 

--- a/lib/src/rust/api/git_manager.dart
+++ b/lib/src/rust/api/git_manager.dart
@@ -454,6 +454,14 @@ Future<void> discardChanges({
   log: log,
 );
 
+Future<void> recreateDeletedIndex({
+  required String pathString,
+  required FutureOr<void> Function(LogType, String) log,
+}) => RustLib.instance.api.crateApiGitManagerRecreateDeletedIndex(
+  pathString: pathString,
+  log: log,
+);
+
 Future<List<(String, ConflictType)>> getConflicting({
   required String pathString,
   required FutureOr<void> Function(LogType, String) log,


### PR DESCRIPTION
This commit is a highlight for review of work in progress on Rust code fixes and error correction work done to maintain the health of the repository.

When the Git index is detected as corrupted, a rescue function automatically deletes it to make it usable again. Unfortunately this causes the index to lose track of the worktree which causes the repository to appear untracked. This commit now attempts to recreate it when such an operation takes place. This is done by running a Rust function `recreateDeletedIndex` which performs a mixed reset to HEAD, effectively rebuilding the index without making any source changes.

This commit also introduces better error handling in `get_conflicting` which currently panics on an unguarded unwrap() if the index is broken. However, activating this fix prevents the error correction code in the dart git manager from running as it previously did, as there's now no "obvious" fault triggering the error correction mechanism. The intention for this work was to introduce an explicit health probe of the repository that can be hooked in at the start of important git workflows sych as UI page opens, background syncs, etc, improving the user experience if the repository needs repair.