### PR TITLE
fix: prevent duplicate directory creation in file explorer

### DIFF
--- a/lib/ui/page/file_explorer.dart
+++ b/lib/ui/page/file_explorer.dart
@@ -707,11 +707,10 @@ class FileExplorerState extends State<FileExplorer> with WidgetsBindingObserver 
                                       CreateFolderDialog.showDialog(context, (folderName) async {
                                         try {
                                           await Directory("${controller.getCurrentPath.replaceFirst(RegExp(r'/$'), '')}/$folderName").create();
+                                          controller.setCurrentPath = "${controller.getCurrentPath.replaceFirst(RegExp(r'/$'), '')}/$folderName";
                                         } catch (e) {
                                           Fluttertoast.showToast(msg: "Failed to create directory: $e", toastLength: Toast.LENGTH_LONG, gravity: null);
                                         }
-                                        await Directory("${controller.getCurrentPath.replaceFirst(RegExp(r'/$'), '')}/$folderName").create();
-                                        controller.setCurrentPath = "${controller.getCurrentPath.replaceFirst(RegExp(r'/$'), '')}/$folderName";
                                       });
                                     },
                                     style: ButtonStyle(


### PR DESCRIPTION
Found a bug where creating a folder calls Directory.create() twice. The second call is outside the try-catch, so if the first fails the second also fails without showing an error toast.

Moved setCurrentPath inside the try block so we only navigate to the new folder if creation succeeds.