### PR TITLE
fix: resolve deadlock when user can't commit due to stale index conflict

### DIFF
--- a/rust/src/api/git_manager.rs
+++ b/rust/src/api/git_manager.rs
@@ -2835,7 +2835,23 @@ pub async fn stage_file_paths(
     match index.add_all(paths.iter(), git2::IndexAddOption::DEFAULT, None) {
         Ok(_) => {}
         Err(_) => {
+            // add_all can fail for paths that don't exist in the working tree (e.g. deleted
+            // files in a conflict). Fall back to update_all and then manually clear any
+            // remaining conflict entries for the requested paths so they don't block later
+            // commit operations.
             swl!(index.update_all(paths.iter(), None))?;
+            for path in &paths {
+                let p = PathBuf::from(path);
+                if index.conflict_get(&p).is_ok() {
+                    if let Err(e) = index.conflict_remove(&p) {
+                        _log(
+                            Arc::clone(&log_callback),
+                            LogType::PushToRepo,
+                            format!("Failed to remove conflict entry for {}: {}", path, e),
+                        );
+                    }
+                }
+            }
         }
     }
 
@@ -3083,14 +3099,85 @@ pub async fn commit_changes(
 
     let mut index = swl!(repo.index())?;
     if index.has_conflicts() {
-        _log(
-            Arc::clone(&log_callback),
-            LogType::PushToRepo,
-            "Index has unresolved conflicts, cannot commit".to_string(),
-        );
-        return Err(git2::Error::from_str(
-            "Cannot commit: unresolved merge conflicts exist. Please resolve conflicts first.",
-        ));
+        let repo_state = repo.state();
+        let can_cleanup_stale_conflicts = repo_state == RepositoryState::Clean;
+
+        if !can_cleanup_stale_conflicts {
+            _log(
+                Arc::clone(&log_callback),
+                LogType::PushToRepo,
+                format!(
+                    "Index has unresolved conflicts during repository state {:?}, cannot commit",
+                    repo_state
+                ),
+            );
+            return Err(git2::Error::from_str(
+                "Cannot commit: unresolved conflicts exist during an active Git operation. Please resolve conflicts first.",
+            ));
+        } else {
+            // Stale conflict entries left in the index when the repository is otherwise clean
+            // (e.g. after cleanup_state() cleared operation metadata but did not clear index
+            // conflict markers). Remove them so that the user's staged changes can be committed
+            // normally.
+            _log(
+                Arc::clone(&log_callback),
+                LogType::PushToRepo,
+                "Removing stale conflict entries from index to unblock commit".to_string(),
+            );
+            let mut conflict_paths: Vec<Vec<u8>> = Vec::new();
+            for conflict_result in swl!(index.conflicts())? {
+                match conflict_result {
+                    Ok(conflict) => {
+                        if let Some(path) = conflict
+                            .our
+                            .map(|e| e.path)
+                            .or_else(|| conflict.their.map(|e| e.path))
+                            .or_else(|| conflict.ancestor.map(|e| e.path))
+                        {
+                            conflict_paths.push(path);
+                        }
+                    }
+                    Err(e) => {
+                        _log(
+                            Arc::clone(&log_callback),
+                            LogType::PushToRepo,
+                            format!("Failed to read conflict entry while cleaning stale conflicts: {}", e),
+                        );
+                    }
+                }
+            }
+            for raw_path in &conflict_paths {
+                // On Unix, file paths can be arbitrary byte sequences that are not valid UTF-8.
+                // Use OsStr::from_bytes so we can still call conflict_remove for those paths
+                // instead of silently leaving them in the index (which would cause write_tree to
+                // fail and keep the deadlock alive).
+                #[cfg(unix)]
+                let path: PathBuf = {
+                    use std::os::unix::ffi::OsStrExt;
+                    PathBuf::from(std::ffi::OsStr::from_bytes(raw_path))
+                };
+                #[cfg(not(unix))]
+                let path: PathBuf = match std::str::from_utf8(raw_path) {
+                    Ok(s) => PathBuf::from(s),
+                    Err(_) => {
+                        // Non-UTF-8 paths cannot be represented on this platform; return a clear
+                        // error rather than silently leaving the index in a conflicted state.
+                        return Err(git2::Error::from_str(&format!(
+                            "Cannot remove stale conflict entry: path is not valid UTF-8 (bytes: {:?})",
+                            raw_path
+                        )));
+                    }
+                };
+                if let Err(e) = index.conflict_remove(&path) {
+                    _log(
+                        Arc::clone(&log_callback),
+                        LogType::PushToRepo,
+                        format!("Failed to remove stale conflict entry {:?}: {}", path, e),
+                    );
+                }
+            }
+            swl!(index.write())?;
+        }
     }
     let updated_tree_oid = swl!(index.write_tree())?;
 

--- a/rust/src/api/git_manager.rs
+++ b/rust/src/api/git_manager.rs
@@ -3177,6 +3177,11 @@ pub async fn commit_changes(
                 }
             }
             swl!(index.write())?;
+            if index.has_conflicts() {
+                return Err(git2::Error::from_str(
+                    "Failed to clear stale conflict entries; cannot commit",
+                ));
+            }
         }
     }
     let updated_tree_oid = swl!(index.write_tree())?;


### PR DESCRIPTION
…ict entries (issue #976) (#1)

* fix: resolve deadlock when user can't commit due to stale index conflict entries (issue #976)

Agent-Logs-Url: https://github.com/pourmand1376/GitSync/sessions/a5564e2e-200f-4010-be8b-ee62e1928390



* Potential fix for pull request finding



* Potential fix for pull request finding



* fix: handle non-UTF-8 conflict paths using OsStr::from_bytes on Unix; log-and-continue on removal failures

Agent-Logs-Url: https://github.com/pourmand1376/GitSync/sessions/019a7b0e-f295-4f51-a889-6def907b5834



* fix: include raw bytes in non-UTF-8 path error message for debuggability

Agent-Logs-Url: https://github.com/pourmand1376/GitSync/sessions/019a7b0e-f295-4f51-a889-6def907b5834



---------